### PR TITLE
fix: increase qr_download_ttl_seconds limit to 24 hours (86400s)

### DIFF
--- a/backend/app/routers/security.py
+++ b/backend/app/routers/security.py
@@ -37,7 +37,7 @@ class SecuritySettingsUpdate(BaseModel):
     scanner_window_seconds: int | None = Field(default=None, ge=10, le=3600)
     block_ip_blocked_dwell: bool | None = None
     ip_blocked_dwell_seconds: int | None = Field(default=None, ge=30, le=3600)
-    qr_download_ttl_seconds: int | None = Field(default=None, ge=60, le=3600)
+    qr_download_ttl_seconds: int | None = Field(default=None, ge=60, le=86400)
     qr_download_max_downloads: int | None = None
     qr_download_pin: str | None = None
     public_download_enabled: bool | None = None

--- a/backend/app/services/qr_download.py
+++ b/backend/app/services/qr_download.py
@@ -22,7 +22,7 @@ class QrDownloadService:
     def __init__(self, db: Session, *, base_url: str = "", ttl_seconds: int = 600, max_downloads: int = 1, pin: str = ""):
         self.db = db
         self.base_url = base_url.rstrip("/")
-        self.ttl_seconds = max(60, min(ttl_seconds, 3600))
+        self.ttl_seconds = max(60, min(ttl_seconds, 86400))
         self.max_downloads = max_downloads if max_downloads in (1, 3, 5) else 1
         self.pin_hash = _hash_pin(pin) if pin else None
 

--- a/backend/app/services/security.py
+++ b/backend/app/services/security.py
@@ -134,7 +134,7 @@ class SecurityService:
                 str(max(30, min(3600, int(payload["ip_blocked_dwell_seconds"])))),
             )
         if "qr_download_ttl_seconds" in payload:
-            _set(db, "qr_download_ttl_seconds", str(max(60, min(3600, int(payload["qr_download_ttl_seconds"])))))
+            _set(db, "qr_download_ttl_seconds", str(max(60, min(86400, int(payload["qr_download_ttl_seconds"])))))
         if "qr_download_max_downloads" in payload:
             val = int(payload["qr_download_max_downloads"])
             _set(db, "qr_download_max_downloads", str(val if val in (1, 3, 5) else 1))


### PR DESCRIPTION
<img width="974" height="746" alt="image" src="https://github.com/user-attachments/assets/b60f94ef-939e-473a-b51c-0b9f3cf68328" />


### Проблема
В интерфейсе панели (на фронтенде) в настройках выдачи профилей для срока действия QR-ссылки (`qr_download_ttl_seconds`) доступны пресеты "15 мин", "1 ч", "4 ч" (14400 секунд), а также ручной ввод до 1440 минут (24 часа / 86400 секунд). 

Однако на бэкенде действовало жесткое ограничение максимум в 3600 секунд (1 час). Из-за этого при попытке сохранить настройки со значением более 1 часа (например, при выборе пресета "4 ч") бэкенд возвращал ошибку валидации:
`Input should be less than or equal to 3600`.

### Решение
Максимально допустимый лимит времени жизни ссылки на бэкенде увеличен с 1 часа (3600 с) до 24 часов (86400 с), что теперь полностью согласуется с ограничениями интерфейса.

Изменения внесены в следующие файлы:
1. `backend/app/routers/security.py` — скорректировано ограничение `le=86400` в схеме валидации Pydantic.
2. `backend/app/services/security.py` — увеличен лимит при сохранении настроек в БД.
3. `backend/app/services/qr_download.py` — обновлен лимит в конструкторе сервиса генерации токенов `QrDownloadService`.
